### PR TITLE
Fix bug where file with only removed lines was being detected as new

### DIFF
--- a/revgrep.go
+++ b/revgrep.go
@@ -207,7 +207,9 @@ type pos struct {
 	hunkPos int // position relative to first @@ in file
 }
 
-// linesChanges returns a map of file names to line numbers being changed
+// linesChanges returns a map of file names to line numbers being changed.
+// If key is nil, the file has been recently added, else it contains a slice
+// of positions that have been added.
 func (c Checker) linesChanged() map[string][]pos {
 	type state struct {
 		file    string
@@ -242,7 +244,7 @@ func (c Checker) linesChanged() map[string][]pos {
 				changes[s.file] = s.changes
 			}
 			// 6 removes "+++ b/"
-			s = state{file: line[6:], hunkPos: -1}
+			s = state{file: line[6:], hunkPos: -1, changes: []pos{}}
 		case strings.HasPrefix(line, "@@ "):
 			//      @@ -1 +2,4 @@
 			// chdr ^^^^^^^^^^^^^

--- a/revgrep_test.go
+++ b/revgrep_test.go
@@ -103,6 +103,8 @@ func TestChangesWriter(t *testing.T) {
 		"10-committed": {"", []string{"main.go:6:"}, "HEAD~1", "HEAD~0"},
 		// static analysis tools with absolute paths should be handled
 		"11-abs-path": {"", []string{"main.go:6:"}, "HEAD~1", "HEAD~0"},
+		// Removing a single line shouldn't raise any issues.
+		"12-removed-lines": {"", nil, "", ""},
 	}
 
 	for stage, test := range tests {

--- a/testdata/make.sh
+++ b/testdata/make.sh
@@ -102,3 +102,28 @@ if [[ "$1" == "11-abs-path" ]]; then
     go vet |& sed -r "s:(.*\.go):$(pwd)/\1:g"
     exit
 fi
+
+# Remove one line on a file with existing issues
+
+if [[ "$1" == "12-removed-lines" ]]; then
+
+    cat > 12-removed-lines.go <<EOF
+package main
+import "fmt"
+var _ = fmt.Sprintf("12-removed-lines %s")
+// some comment that will be removed
+EOF
+
+    git add .
+    git commit -m "Commit" > /dev/null
+
+    cat > 12-removed-lines.go <<EOF
+package main
+import "fmt"
+var _ = fmt.Sprintf("12-removed-lines %s")
+EOF
+
+    git add .
+    git commit -m "Commit" > /dev/null
+    close
+fi


### PR DESCRIPTION
Checker.linesChanged returns a map of files and a slice of positions that have changed. If the slice was nil, it was an indication that the file was new, so any issues found in that file were new and should be raised. But if the file only had lines that were removed (not added or modified), the slice would also be new.

This change introduces a third state, where an empty slice would indicate no lines have been added (or modified).

I don't think this is an ideal change, the bug was likely introduced in 8d3df443d0743c5b4346687e60ae485d75fbe3be, where previous to that new files had an artificial diff created indicating all lines were added. That commit was designed to remove the external dependency in GNU diff.

I've settled on this change simply because it's straight forward and doesn't add another dependency, but I'm not convinced it's the best change either.

There's other related issues to this, some tools may want to see issues on lines that have been removed, such as apicompat, a larger change may want to take this into account.

Fixes https://github.com/bradleyfalzon/gopherci/issues/126.
Related to https://github.com/bradleyfalzon/gopherci/issues/86.
Related to https://github.com/bradleyfalzon/gopherci/issues/63.