### PR TITLE
Fix revgrep using for any subdir of the git repo

### DIFF
--- a/revgrep.go
+++ b/revgrep.go
@@ -308,7 +308,7 @@ func GitPatch(revisionFrom, revisionTo string) (io.Reader, []string, error) {
 	}
 
 	if revisionFrom != "" {
-		cmd := exec.Command("git", "diff", revisionFrom)
+		cmd := exec.Command("git", "diff", "--relative", revisionFrom)
 		if revisionTo != "" {
 			cmd.Args = append(cmd.Args, revisionTo)
 		}
@@ -325,7 +325,7 @@ func GitPatch(revisionFrom, revisionTo string) (io.Reader, []string, error) {
 
 	// make a patch for unstaged changes
 	// use --no-prefix to remove b/ given: +++ b/main.go
-	cmd := exec.Command("git", "diff")
+	cmd := exec.Command("git", "diff", "--relative")
 	cmd.Stdout = &patch
 	if err := cmd.Run(); err != nil {
 		return nil, nil, fmt.Errorf("error executing git diff: %s", err)
@@ -340,7 +340,7 @@ func GitPatch(revisionFrom, revisionTo string) (io.Reader, []string, error) {
 
 	// check for changes in recent commit
 
-	cmd = exec.Command("git", "diff", "HEAD~")
+	cmd = exec.Command("git", "diff", "--relative", "HEAD~")
 	cmd.Stdout = &patch
 	if err := cmd.Run(); err != nil {
 		return nil, nil, fmt.Errorf("error executing git diff HEAD~: %s", err)


### PR DESCRIPTION
Fixed bug when launching revgrep in subdir of the git root would always give empty result.

Didn't manage to launch tests, they not working for me in any tag or master version.
Tested manually if this works for relative / absolute pathes in input.
