### PR TITLE
Add go.mod to expose revgrep to module-aware setups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/bradleyfalzon/revgrep
+
+go 1.18


### PR DESCRIPTION
The go version here is somewhat arbitrary, happy to pick a different one than 1.18.